### PR TITLE
PIMS-2025 BC Services Card & Azure IDIR

### DIFF
--- a/__tests__/utils/user.test.ts
+++ b/__tests__/utils/user.test.ts
@@ -49,6 +49,36 @@ describe('getUserInfo function', () => {
     expect(result?.client_roles).toStrictEqual([]);
   });
 
+  // Test case: should normalize user data correctly for identity_provider 'idir'
+  it('should normalize user data correctly for identity_provider idir', () => {
+    const userInfo = {
+      preferred_username: 'testUser',
+      display_name: 'Test User',
+      identity_provider: 'idir',
+      given_name: 'Test',
+      family_name: 'User',
+    } as OriginalSSOUser;
+    const normalizedUser = normalizeUser(userInfo);
+    expect(normalizedUser?.identity_provider).toBe('idir');
+    expect(normalizedUser?.first_name).toBe('Test');
+    expect(normalizedUser?.last_name).toBe('User');
+  });
+
+    // Test case: should normalize user data correctly for identity_provider 'azureidir'
+    it('should normalize user data correctly for identity_provider azureidir', () => {
+      const userInfo = {
+        preferred_username: 'testUser',
+        display_name: 'Test User',
+        given_name: 'Test',
+        family_name: 'User',
+        identity_provider: 'azureidir',
+      } as OriginalSSOUser;
+      const normalizedUser = normalizeUser(userInfo);
+      expect(normalizedUser?.identity_provider).toBe('azureidir');
+      expect(normalizedUser?.first_name).toBe('Test');
+      expect(normalizedUser?.last_name).toBe('User');
+    });
+
   // Test case: should normalize user data correctly for identity_provider 'bceidbasic'
   it('should normalize user data correctly for identity_provider bceidbasic', () => {
     const userInfo = {

--- a/__tests__/utils/user.test.ts
+++ b/__tests__/utils/user.test.ts
@@ -64,20 +64,20 @@ describe('getUserInfo function', () => {
     expect(normalizedUser?.last_name).toBe('User');
   });
 
-    // Test case: should normalize user data correctly for identity_provider 'azureidir'
-    it('should normalize user data correctly for identity_provider azureidir', () => {
-      const userInfo = {
-        preferred_username: 'testUser',
-        display_name: 'Test User',
-        given_name: 'Test',
-        family_name: 'User',
-        identity_provider: 'azureidir',
-      } as OriginalSSOUser;
-      const normalizedUser = normalizeUser(userInfo);
-      expect(normalizedUser?.identity_provider).toBe('azureidir');
-      expect(normalizedUser?.first_name).toBe('Test');
-      expect(normalizedUser?.last_name).toBe('User');
-    });
+  // Test case: should normalize user data correctly for identity_provider 'azureidir'
+  it('should normalize user data correctly for identity_provider azureidir', () => {
+    const userInfo = {
+      preferred_username: 'testUser',
+      display_name: 'Test User',
+      given_name: 'Test',
+      family_name: 'User',
+      identity_provider: 'azureidir',
+    } as OriginalSSOUser;
+    const normalizedUser = normalizeUser(userInfo);
+    expect(normalizedUser?.identity_provider).toBe('azureidir');
+    expect(normalizedUser?.first_name).toBe('Test');
+    expect(normalizedUser?.last_name).toBe('User');
+  });
 
   // Test case: should normalize user data correctly for identity_provider 'bceidbasic'
   it('should normalize user data correctly for identity_provider bceidbasic', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,13 +6,15 @@ export type HasRolesOptions = {
 };
 
 export type IdirIdentityProvider = 'idir';
+export type AzureIdirIdentityProvider = 'azureidir';
 export type BceidIdentityProvider = 'bceidbasic' | 'bceidbusiness' | 'bceidboth';
 export type GithubIdentityProvider = 'githubbcgov' | 'githubpublic';
 
 export type IdentityProvider =
   | IdirIdentityProvider
   | BceidIdentityProvider
-  | GithubIdentityProvider;
+  | GithubIdentityProvider
+  | AzureIdirIdentityProvider;
 
 export type BaseSSOUser = {
   name?: string;
@@ -47,7 +49,13 @@ export type SSOGithubUser = {
   last_name?: string;
 };
 
-export type OriginalSSOUser = BaseSSOUser & SSOIdirUser & SSOBCeIDUser & SSOGithubUser;
+export type SSOBcServicesCardUser = {
+  given_name?: string;
+  family_name?: string;
+  first_name?: string;
+}
+
+export type OriginalSSOUser = BaseSSOUser & SSOIdirUser & SSOBCeIDUser & SSOGithubUser & SSOBcServicesCardUser;
 
 export type SSOUser = BaseSSOUser & {
   guid: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ export type IdirIdentityProvider = 'idir';
 export type AzureIdirIdentityProvider = 'azureidir';
 export type BceidIdentityProvider = 'bceidbasic' | 'bceidbusiness' | 'bceidboth';
 export type GithubIdentityProvider = 'githubbcgov' | 'githubpublic';
+// BC Services Card uses SSO_CLIENT_ID as the provider.
 
 export type IdentityProvider =
   | IdirIdentityProvider

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,10 +51,14 @@ export type SSOGithubUser = {
 export type SSOBcServicesCardUser = {
   given_name?: string;
   family_name?: string;
-  first_name?: string;
 }
 
-export type OriginalSSOUser = BaseSSOUser & SSOIdirUser & SSOBCeIDUser & SSOGithubUser & SSOBcServicesCardUser;
+export type OriginalSSOUser = 
+  & BaseSSOUser 
+  & SSOIdirUser 
+  & SSOBCeIDUser 
+  & SSOGithubUser 
+  & SSOBcServicesCardUser;
 
 export type SSOUser = BaseSSOUser & {
   guid: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,17 +5,15 @@ export type HasRolesOptions = {
   requireAllRoles?: boolean;
 };
 
-export type IdirIdentityProvider = 'idir';
-export type AzureIdirIdentityProvider = 'azureidir';
+export type IdirIdentityProvider = 'idir' | 'azureidir';
 export type BceidIdentityProvider = 'bceidbasic' | 'bceidbusiness' | 'bceidboth';
 export type GithubIdentityProvider = 'githubbcgov' | 'githubpublic';
 // BC Services Card uses SSO_CLIENT_ID as the provider.
 
-export type IdentityProvider =
+export type IdentityProvider = 
   | IdirIdentityProvider
   | BceidIdentityProvider
-  | GithubIdentityProvider
-  | AzureIdirIdentityProvider;
+  | GithubIdentityProvider;
 
 export type BaseSSOUser = {
   name?: string;

--- a/src/utils/user.ts
+++ b/src/utils/user.ts
@@ -51,27 +51,43 @@ export const normalizeUser = (userInfo: OriginalSSOUser | null): SSOUser | null 
   } = userInfo;
 
   // Normalize properties
-  let guid = userInfo?.idir_user_guid ?? '';
-  let username = userInfo?.idir_username ?? '';
-  let first_name = userInfo?.given_name ?? '';
-  let last_name = userInfo?.family_name ?? '';
+  let guid;
+  let username;
+  let first_name;
+  let last_name;
 
-  if (
-    identity_provider === 'bceidbasic' ||
-    identity_provider === 'bceidbusiness' ||
-    identity_provider === 'bceidboth'
-  ) {
-    // BCeID
-    guid = userInfo?.bceid_user_guid ?? '';
-    username = userInfo?.bceid_username ?? '';
-    first_name = userInfo?.display_name.split(' ')[0];
-    last_name = userInfo?.display_name.split(' ')[1];
-  } else if (identity_provider === 'githubbcgov' || identity_provider === 'githubpublic') {
-    // GitHub
-    guid = userInfo?.github_id ?? '';
-    username = userInfo?.github_username ?? '';
-    first_name = userInfo?.display_name.split(' ')[0];
-    last_name = userInfo?.display_name.split(' ')[1];
+  switch (identity_provider) {
+    case 'idir':
+    case 'azureidir':
+      // IDIR
+      guid = userInfo?.idir_user_guid ?? '';
+      username = userInfo?.idir_username ?? '';
+      first_name = userInfo?.given_name ?? '';
+      last_name = userInfo?.family_name ?? '';
+      break;
+    case 'bceidbasic':
+    case 'bceidboth':
+    case 'bceidbusiness':
+      // BCeID
+      guid = userInfo?.bceid_user_guid ?? '';
+      username = userInfo?.bceid_username ?? '';
+      first_name = userInfo?.display_name.split(' ')[0] ?? '';
+      last_name = userInfo?.display_name.split(' ')[1] ?? '';
+      break;
+    case 'githubbcgov':
+    case 'githubpublic':
+      // GitHub
+      guid = userInfo?.github_id ?? '';
+      username = userInfo?.github_username ?? '';
+      first_name = userInfo?.display_name.split(' ')[0] ?? '';
+      last_name = userInfo?.display_name.split(' ')[1] ?? '';
+      break;
+    default:
+      guid = userInfo?.preferred_username.split('@').at(0) ?? '';
+      username = userInfo?.preferred_username ?? '';
+      first_name = userInfo?.given_name ?? '';
+      last_name = userInfo?.family_name ?? '';
+      break;
   }
 
   // Normalized user

--- a/techdocs/docs/using-the-package/module-exports.md
+++ b/techdocs/docs/using-the-package/module-exports.md
@@ -21,7 +21,6 @@ import {
   HasRolesOptions, // Type of optional second parameter for req?.user?.hasRoles()
   IdentityProvider, // Combined type for identity providers.
   IdirIdentityProvider, // Used for more efficient login.
-  AzureIdirIdentityProvider, // Used for more efficient login.
   BceidIdentityProvider, // Used for more efficient login.
   GithubIdentityProvider, // Used for more efficient login.
   // BC Services Card has no fixed identity provider. It uses SSO_CLIENT_ID.

--- a/techdocs/docs/using-the-package/module-exports.md
+++ b/techdocs/docs/using-the-package/module-exports.md
@@ -15,12 +15,15 @@ import {
   SSOIdirUser, // User types specific to Idir users.
   SSOBCeIDUser, // User types specific to BCeID users.
   SSOGithubUser, // User types specific to Github users.
+  SSOBcServicesCardUser, // User types specific to BC Services Card users.
   SSOOptions, // Type of optional second parameter for sso()
   ProtectedRouteOptions, // Type of optional second parameter for protectedRoute()
   HasRolesOptions, // Type of optional second parameter for req?.user?.hasRoles()
   IdentityProvider, // Combined type for identity providers.
   IdirIdentityProvider, // Used for more efficient login.
+  AzureIdirIdentityProvider, // Used for more efficient login.
   BceidIdentityProvider, // Used for more efficient login.
   GithubIdentityProvider, // Used for more efficient login.
+  // BC Services Card has no fixed identity provider. It uses SSO_CLIENT_ID.
 } from '@bcgov/citz-imb-sso-express';
 ```

--- a/techdocs/docs/using-the-package/typescript-types.md
+++ b/techdocs/docs/using-the-package/typescript-types.md
@@ -14,7 +14,7 @@ import { RequestHandler, Application, Request, Response } from 'express';
 type HasRolesOptions = {
     requireAllRoles?: boolean;
 };
-type IdirIdentityProvider = 'idir';
+type IdirIdentityProvider = 'idir' | 'azureidir';
 type BceidIdentityProvider = 'bceidbasic' | 'bceidbusiness' | 'bceidboth';
 type GithubIdentityProvider = 'githubbcgov' | 'githubpublic';
 type IdentityProvider = IdirIdentityProvider | BceidIdentityProvider | GithubIdentityProvider;
@@ -47,7 +47,12 @@ type SSOGithubUser = {
     first_name?: string;
     last_name?: string;
 };
-type OriginalSSOUser = BaseSSOUser & SSOIdirUser & SSOBCeIDUser & SSOGithubUser;
+type SSOBcServicesCardUser = {
+    given_name?: string;
+    family_name?: string;
+    first_name?: string;
+}
+type OriginalSSOUser = BaseSSOUser & SSOIdirUser & SSOBCeIDUser & SSOGithubUser & SSOBcServicesCardUser;
 type SSOUser = BaseSSOUser & {
     guid: string;
     username: string;
@@ -135,5 +140,5 @@ declare const getNewTokens: (refresh_token: string) => Promise<null | {
     expires_in: number;
 }>;
 
-export { type BaseSSOUser, type BceidIdentityProvider, type GithubIdentityProvider, type HasRolesOptions, type IdentityProvider, type IdirIdentityProvider, type OriginalSSOUser, type ProtectedRouteOptions, type SSOBCeIDUser, type SSOGithubUser, type SSOIdirUser, type SSOOptions, type SSOUser, checkForUpdates, debug_d as debug, decodeJWT, encodeJWT, getLoginURL, getLogoutURL, getNewTokens, getTokens, getUserInfo, hasAllRoles, hasAtLeastOneRole, hasRoles, isJWTValid, login, loginCallback, logout, logoutCallback, normalizeUser, parseJWT, protectedRoute, refreshToken, sso };
+export { type BaseSSOUser, type BceidIdentityProvider, type GithubIdentityProvider, type HasRolesOptions, type IdentityProvider, type IdirIdentityProvider, type OriginalSSOUser, type ProtectedRouteOptions, type SSOBCeIDUser, type SSOGithubUser, type SSOIdirUser, type SSOOptions, type SSOUser, type SSOBcServicesCardUser, checkForUpdates, debug_d as debug, decodeJWT, encodeJWT, getLoginURL, getLogoutURL, getNewTokens, getTokens, getUserInfo, hasAllRoles, hasAtLeastOneRole, hasRoles, isJWTValid, login, loginCallback, logout, logoutCallback, normalizeUser, parseJWT, protectedRoute, refreshToken, sso };
 ```

--- a/techdocs/docs/using-the-package/typescript-types.md
+++ b/techdocs/docs/using-the-package/typescript-types.md
@@ -14,7 +14,7 @@ import { RequestHandler, Application, Request, Response } from 'express';
 type HasRolesOptions = {
     requireAllRoles?: boolean;
 };
-type IdirIdentityProvider = 'idir' | 'azureidir';
+type IdirIdentityProvider = 'idir';
 type BceidIdentityProvider = 'bceidbasic' | 'bceidbusiness' | 'bceidboth';
 type GithubIdentityProvider = 'githubbcgov' | 'githubpublic';
 type IdentityProvider = IdirIdentityProvider | BceidIdentityProvider | GithubIdentityProvider;
@@ -47,12 +47,7 @@ type SSOGithubUser = {
     first_name?: string;
     last_name?: string;
 };
-type SSOBcServicesCardUser = {
-    given_name?: string;
-    family_name?: string;
-    first_name?: string;
-}
-type OriginalSSOUser = BaseSSOUser & SSOIdirUser & SSOBCeIDUser & SSOGithubUser & SSOBcServicesCardUser;
+type OriginalSSOUser = BaseSSOUser & SSOIdirUser & SSOBCeIDUser & SSOGithubUser;
 type SSOUser = BaseSSOUser & {
     guid: string;
     username: string;
@@ -140,5 +135,5 @@ declare const getNewTokens: (refresh_token: string) => Promise<null | {
     expires_in: number;
 }>;
 
-export { type BaseSSOUser, type BceidIdentityProvider, type GithubIdentityProvider, type HasRolesOptions, type IdentityProvider, type IdirIdentityProvider, type OriginalSSOUser, type ProtectedRouteOptions, type SSOBCeIDUser, type SSOGithubUser, type SSOIdirUser, type SSOOptions, type SSOUser, type SSOBcServicesCardUser, checkForUpdates, debug_d as debug, decodeJWT, encodeJWT, getLoginURL, getLogoutURL, getNewTokens, getTokens, getUserInfo, hasAllRoles, hasAtLeastOneRole, hasRoles, isJWTValid, login, loginCallback, logout, logoutCallback, normalizeUser, parseJWT, protectedRoute, refreshToken, sso };
+export { type BaseSSOUser, type BceidIdentityProvider, type GithubIdentityProvider, type HasRolesOptions, type IdentityProvider, type IdirIdentityProvider, type OriginalSSOUser, type ProtectedRouteOptions, type SSOBCeIDUser, type SSOGithubUser, type SSOIdirUser, type SSOOptions, type SSOUser, checkForUpdates, debug_d as debug, decodeJWT, encodeJWT, getLoginURL, getLogoutURL, getNewTokens, getTokens, getUserInfo, hasAllRoles, hasAtLeastOneRole, hasRoles, isJWTValid, login, loginCallback, logout, logoutCallback, normalizeUser, parseJWT, protectedRoute, refreshToken, sso };
 ```


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  

MVP-100: Title of Ticket
-->

## 🎯 Summary

<!-- COMPLETE JIRA LINK BELOW -->  
[PIMS-2025](https://citz-imb.atlassian.net/browse/PIMS-2025)

[Corresponding React change](https://github.com/bcgov/citz-imb-sso-react/pull/166)


<!-- PROVIDE BELOW an explanation of your changes and any images to support your explanation -->
Note: BC Services Card uses the SSO_CLIENT_ID as identity provider field. 

This means your preferred_username will also look like `guid@clientID`

SSO team has confirmed that this is intentional.

## Changes
- Updated the normalizeUser function to accommodate alternative identity providers. Wanted to find a way to do a dynamic string literal for the type based on the SSO_CLIENT_ID, but it seems like that might not be an option.
- Added some types to correspond to these new login options.

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](/CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - I have consulted with the team if introducing a new dependency.
> - My changes generate no new warnings.
